### PR TITLE
DEVICE-129 - lastSeenOn

### DIFF
--- a/src/steps/device/__snapshots__/index.test.ts.snap
+++ b/src/steps/device/__snapshots__/index.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetch-devices 1`] = `
+Array [
+  Object {
+    "_class": Array [
+      "Device",
+    ],
+    "_key": "simplemdm_device:872292",
+    "_type": "simplemdm_device",
+    "bluetoothMac": "14:7D:DA:4E:50:6D",
+    "buildVersion": "21A559",
+    "category": "other",
+    "createdOn": undefined,
+    "deviceCapacity": 250,
+    "deviceId": "872292",
+    "deviceName": "RickandMorty-MBP",
+    "displayName": "JupiterOne Macbook Air",
+    "enrollmentChannels": Array [
+      "device",
+      "user",
+    ],
+    "ethernetMacs": Array [
+      "14:7d:da:4f:73:10",
+    ],
+    "id": "872292",
+    "lastSeenAt": 1655845792000,
+    "lastSeenIp": "[REDACTED]",
+    "lastSeenOn": 1655845792000,
+    "macAddress": Array [
+      "14:7d:da:4f:73:10",
+      "14:7D:DA:4E:50:6D",
+      "14:7d:da:4f:73:10",
+    ],
+    "make": "Apple Inc.",
+    "model": "MacBookAir9,1",
+    "modelName": "MacBook Air (Retina, 13-inch, 2020)",
+    "name": "JupiterOne Macbook Air",
+    "osVersion": "12.0.1",
+    "processorArchitecture": "Intel",
+    "productName": "MacBookAir9,1",
+    "serial": "C02D91CNPV4M",
+    "serialNumber": "C02D91CNPV4M",
+    "status": "assigned",
+    "uniqueIdentifier": "644D7162-2B41-5A68-9AA7-8DB4FC6ABFF5",
+    "wifiMac": "14:7d:da:4f:73:10",
+  },
+]
+`;

--- a/src/steps/device/converter.ts
+++ b/src/steps/device/converter.ts
@@ -28,6 +28,7 @@ export function createDeviceEntity(device: SimpleMDMDevice): Entity {
         deviceId: device.id.toString(),
         name: device.attributes.name,
         lastSeenAt: lastSeenAt && lastSeenAt > 0 ? lastSeenAt : undefined,
+        lastSeenOn: lastSeenAt,
         lastSeenIp: device.attributes.last_seen_ip,
         status:
           device.attributes.status == 'enrolled'
@@ -42,11 +43,16 @@ export function createDeviceEntity(device: SimpleMDMDevice): Entity {
         productName: device.attributes.product_name,
         uniqueIdentifier: device.attributes.unique_identifier,
         serial: device.attributes.serial_number,
+        serialNumber: device.attributes.serial_number,
         processorArchitecture: device.attributes.processor_architecture,
         deviceCapacity: device.attributes.device_capacity,
         bluetoothMac: device.attributes.bluetooth_mac,
         ethernetMacs: device.attributes.ethernet_macs,
         wifiMac: device.attributes.wifi_mac,
+        macAddress: [
+          device.attributes.wifi_mac,
+          device.attributes.bluetooth_mac,
+        ].concat(device.attributes.ethernet_macs),
         category: `other`,
         make: `Apple Inc.`,
       },

--- a/src/steps/device/index.test.ts
+++ b/src/steps/device/index.test.ts
@@ -3,6 +3,7 @@ import { executeStepWithDependencies } from '@jupiterone/integration-sdk-testing
 import { buildStepTestConfigForStep } from '../../../test/config';
 import { Recording, setupProjectRecording } from '../../../test/recording';
 import { Steps } from '../constants';
+import { omit } from 'lodash';
 
 // See test/README.md for details
 let recording: Recording;
@@ -19,4 +20,7 @@ test('fetch-devices', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.DEVICES);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(
+    stepResult.collectedEntities.map((e) => omit(e, ['_rawData'])),
+  ).toMatchSnapshot();
 });


### PR DESCRIPTION
# Description

## Summary

Add lastSeenOn, serialNumber, and macAddress to Devices

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
